### PR TITLE
Oculta la Micolo Hideout en la dex (issue #2)

### DIFF
--- a/data/wild/johto_grass.asm
+++ b/data/wild/johto_grass.asm
@@ -2,6 +2,62 @@
 
 JohtoGrassWildMons: ; 0x2a5e9
 
+	map_id MICOLO_HIDEOUT
+	db 10 percent, 10 percent, 10 percent ; encounter rates: morn/day/nite
+	; morn
+	db 100, ARTICUNO
+	db 100, ZAPDOS
+	db 100, MOLTRES
+	db 100, LUGIA
+	db 100, HO_OH
+	db 100, MEWTWO
+	db 100, MEWTWO
+	; day
+	db 100, ARTICUNO
+	db 100, ZAPDOS
+	db 100, MOLTRES
+	db 100, LUGIA
+	db 100, HO_OH
+	db 100, MEWTWO
+	db 100, MEWTWO
+	; nite
+	db 100, ARTICUNO
+	db 100, ZAPDOS
+	db 100, MOLTRES
+	db 100, LUGIA
+	db 100, HO_OH
+	db 100, MEWTWO
+	db 100, MEWTWO
+
+	map_id MICOLO_HIDEOUT_BASEMENT
+	db 10 percent, 10 percent, 10 percent ; encounter rates: morn/day/nite
+	; morn
+	db 100, ARTICUNO
+	db 100, ZAPDOS
+	db 100, MOLTRES
+	db 100, LUGIA
+	db 100, HO_OH
+	db 100, MEWTWO
+	db 100, MEWTWO
+	; day
+	db 100, ARTICUNO
+	db 100, ZAPDOS
+	db 100, MOLTRES
+	db 100, LUGIA
+	db 100, HO_OH
+	db 100, MEWTWO
+	db 100, MEWTWO
+	; nite
+	db 100, ARTICUNO
+	db 100, ZAPDOS
+	db 100, MOLTRES
+	db 100, LUGIA
+	db 100, HO_OH
+	db 100, MEWTWO
+	db 100, MEWTWO
+
+JohtoGrassWildMonsForDex: ; the ones before this line will not be shown in dex
+
 	map_id SPROUT_TOWER_2F
 	db 2 percent, 2 percent, 2 percent ; encounter rates: morn/day/nite
 	; morn
@@ -1648,59 +1704,5 @@ JohtoGrassWildMons: ; 0x2a5e9
 	db 85, NOCTOWL
 	db 90, MURKROW
 	db 90, MURKROW
-
-	map_id MICOLO_HIDEOUT
-	db 10 percent, 10 percent, 10 percent ; encounter rates: morn/day/nite
-	; morn
-	db 100, ARTICUNO
-	db 100, ZAPDOS
-	db 100, MOLTRES
-	db 100, LUGIA
-	db 100, HO_OH
-	db 100, MEWTWO
-	db 100, MEWTWO
-	; day
-	db 100, ARTICUNO
-	db 100, ZAPDOS
-	db 100, MOLTRES
-	db 100, LUGIA
-	db 100, HO_OH
-	db 100, MEWTWO
-	db 100, MEWTWO
-	; nite
-	db 100, ARTICUNO
-	db 100, ZAPDOS
-	db 100, MOLTRES
-	db 100, LUGIA
-	db 100, HO_OH
-	db 100, MEWTWO
-	db 100, MEWTWO
-
-	map_id MICOLO_HIDEOUT_BASEMENT
-	db 10 percent, 10 percent, 10 percent ; encounter rates: morn/day/nite
-	; morn
-	db 100, ARTICUNO
-	db 100, ZAPDOS
-	db 100, MOLTRES
-	db 100, LUGIA
-	db 100, HO_OH
-	db 100, MEWTWO
-	db 100, MEWTWO
-	; day
-	db 100, ARTICUNO
-	db 100, ZAPDOS
-	db 100, MOLTRES
-	db 100, LUGIA
-	db 100, HO_OH
-	db 100, MEWTWO
-	db 100, MEWTWO
-	; nite
-	db 100, ARTICUNO
-	db 100, ZAPDOS
-	db 100, MOLTRES
-	db 100, LUGIA
-	db 100, HO_OH
-	db 100, MEWTWO
-	db 100, MEWTWO
 
 	db -1 ; end

--- a/engine/radio.asm
+++ b/engine/radio.asm
@@ -219,17 +219,17 @@ OaksPKMNTalk4:
 	; bc now contains the chosen map's group and number indices.
 	push bc
 
-	; Search the JohtoGrassWildMons array for the chosen map.
-	ld hl, JohtoGrassWildMons
+	; Search the JohtoGrassWildMonsForDex array for the chosen map.
+	ld hl, JohtoGrassWildMonsForDex ; this excludes the Hideout to save a few microseconds
 .loop
-	ld a, BANK(JohtoGrassWildMons)
+	ld a, BANK(JohtoGrassWildMonsForDex)
 	call GetFarByte
 	cp -1
 	jr z, .overflow
 	inc hl
 	cp b
 	jr nz, .next
-	ld a, BANK(JohtoGrassWildMons)
+	ld a, BANK(JohtoGrassWildMonsForDex)
 	call GetFarByte
 	cp c
 	jr z, .done
@@ -266,7 +266,7 @@ endr
 	add hl, de
 	add hl, de
 	inc hl ; skip level
-	ld a, BANK(JohtoGrassWildMons)
+	ld a, BANK(JohtoGrassWildMonsForDex)
 	call GetFarByte
 	ld [wNamedObjectIndexBuffer], a
 	ld [wCurPartySpecies], a

--- a/engine/wildmons.asm
+++ b/engine/wildmons.asm
@@ -37,7 +37,7 @@ FindNest: ; 2a01f
 	and a
 	jr nz, .kanto
 	decoord 0, 0
-	ld hl, JohtoGrassWildMons
+	ld hl, JohtoGrassWildMonsForDex ; this excludes the Hideout
 	call .FindGrass
 	ld hl, JohtoWaterWildMons
 	call .FindWater
@@ -829,7 +829,7 @@ RandomUnseenWildMon: ; 2a4ab
 	farcall GetCallerLocation
 	ld d, b
 	ld e, c
-	ld hl, JohtoGrassWildMons
+	ld hl, JohtoGrassWildMonsForDex ; this excludes the Hideout to save a few microseconds, as there are no callers there
 	ld bc, GRASS_WILDDATA_LENGTH
 	call LookUpWildmonsForMapDE
 	jr c, .GetGrassmon
@@ -902,7 +902,7 @@ RandomPhoneWildMon: ; 2a51f
 	farcall GetCallerLocation
 	ld d, b
 	ld e, c
-	ld hl, JohtoGrassWildMons
+	ld hl, JohtoGrassWildMonsForDex ; this excludes the Hideout to save a few microseconds, as there are no callers there
 	ld bc, GRASS_WILDDATA_LENGTH
 	call LookUpWildmonsForMapDE
 	jr c, .ok


### PR DESCRIPTION
Esto debería (no lo he probado pero parece sencillo) arreglar el issue #2 sin efectos indeseados.

Esto pone los datos de los pokes de la "hierba" (fuera del agua) de Micolo Hideout al principio, antes que las demás, y añade justo después un puntero `JohtoGrassWildMonsForDex` de forma que lo que apunte ahí (todo menos el código de ver qué pokes aparecen en la hierba actual, es decir: el código de buscar el área de pokes y cosas de info de pokes salvajes que te pasan por la radio y el teléfono) ignorará completamente la existencia de pokes salvajes en la Hideout.

El único sitio que sigue apuntando a `JohtoGrassWildMons`, si no esido engañado por el buscador de GitHub, es el de comprobar los pokes salvajes que aparecen "en la hierba" (fuera del agua) del mapa actual de Johto, por lo que seguirán apareciendo en la Micolo Hideout, para máxima desesperación de los visitantes, particularmente de los que no eligieron a Larvitar.