### PR TITLE
Modifica randomizador para que no exceda el nivel 100 (issue #3)

### DIFF
--- a/engine/wildmons.asm
+++ b/engine/wildmons.asm
@@ -331,6 +331,15 @@ ChooseWildEncounter: ; 2a14f
 	ld b, a
 ; Max Level
 	ld a, [de]
+	add b
+	cp 101 ; check that the max level does not exceed 100
+	jr c, .valid_max
+	ld a, 100 ; the range will be [min, 100] unless min > 100
+	cp b
+	jr nc, .valid_max
+	ld a, b ; if min > 100, then max = min
+.valid_max
+	sub b
 ; Min Level
 	ld d, b
 	ld b, a


### PR DESCRIPTION
Esto debería (no lo puedo probar) atajar el issue #3.

Lo que hace es que, si el rango de niveles es [mínimo, número mayor que 100] (donde mínimo es el que indica la tabla de pokes salvajes), entonces lo cambia a [mínimo, 100]. Si por lo que sea el nivel mínimo ya era mayor que 100 (que no es el caso en Midele Crystal, pero por si acaso), entonces el poke saldrá a ese nivel mínimo, ya que se fija el rango a [mínimo, mínimo].